### PR TITLE
allow enclave to start execution from _start and put bss data in .data section

### DIFF
--- a/app.lds
+++ b/app.lds
@@ -13,8 +13,10 @@ SECTIONS
     *(.rdata)
     *(.rodata)
   }
-  .data : { *(.data) }
-  .bss : { *(.bss) }
+  .data : { 
+	*(.data) 
+	*(.bss)
+  }
   .debug : { *(.debug) }
 
   . = ALIGN(0x1000);

--- a/musl/crt/crt1.c
+++ b/musl/crt/crt1.c
@@ -13,7 +13,7 @@ int __libc_start_main(int (*)(), int, char **,
 
 void _start_c(long *p)
 {
-	int argc = p[0];
-	char **argv = (void *)(p+1);
+  int argc = 1;
+  char *argv[] = {"enclave.signed.so", 0, 0, 0};
 	__libc_start_main(main, argc, argv, _init, _fini, 0);
 }

--- a/musl/crt/crt1.c
+++ b/musl/crt/crt1.c
@@ -13,7 +13,7 @@ int __libc_start_main(int (*)(), int, char **,
 
 void _start_c(long *p)
 {
-  int argc = 1;
-  char *argv[] = {"enclave.signed.so", 0, 0, 0};
-	__libc_start_main(main, argc, argv, _init, _fini, 0);
+    int argc = 1;
+    char *argv[] = {0, 0, 0, 0};
+    __libc_start_main(main, argc, argv, _init, _fini, 0);
 }

--- a/musl/src/env/__init_tls.c
+++ b/musl/src/env/__init_tls.c
@@ -19,7 +19,7 @@ int __init_tp(void *p)
 	if (r < 0) return -1;
 	if (!r) libc.can_do_threads = 1;
 	td->detach_state = DT_JOINABLE;
-	td->tid = __syscall(SYS_set_tid_address, &__thread_list_lock);
+	// td->tid = __syscall(SYS_set_tid_address, &__thread_list_lock);
 	td->locale = &libc.global_locale;
 	td->robust_list.head = &td->robust_list.head;
 	td->sysinfo = __sysinfo;

--- a/musl/src/env/__libc_start_main.c
+++ b/musl/src/env/__libc_start_main.c
@@ -42,17 +42,17 @@ void __init_libc(char **envp, char *pn)
 	if (aux[AT_UID]==aux[AT_EUID] && aux[AT_GID]==aux[AT_EGID]
 		&& !aux[AT_SECURE]) return;
 
-	struct pollfd pfd[3] = { {.fd=0}, {.fd=1}, {.fd=2} };
-	int r =
-#ifdef SYS_poll
-	__syscall(SYS_poll, pfd, 3, 0);
-#else
-	__syscall(SYS_ppoll, pfd, 3, &(struct timespec){0}, 0, _NSIG/8);
-#endif
-	if (r<0) a_crash();
-	for (i=0; i<3; i++) if (pfd[i].revents&POLLNVAL)
-		if (__sys_open("/dev/null", O_RDWR)<0)
-			a_crash();
+// 	struct pollfd pfd[3] = { {.fd=0}, {.fd=1}, {.fd=2} };
+// 	int r =
+// #ifdef SYS_poll
+// 	__syscall(SYS_poll, pfd, 3, 0);
+// #else
+// 	__syscall(SYS_ppoll, pfd, 3, &(struct timespec){0}, 0, _NSIG/8);
+// #endif
+// 	if (r<0) a_crash();
+// 	for (i=0; i<3; i++) if (pfd[i].revents&POLLNVAL)
+// 		if (__sys_open("/dev/null", O_RDWR)<0)
+// 			a_crash();
 	libc.secure = 1;
 }
 


### PR DESCRIPTION
This commit enables the enclave to start execution from _start. Starting execution from _start allows the constructors of global objects to be executed before main, and it can initialize the thread structure. This addresses the bug in stringstream, as __pthread_self() is used within stringstream. Put bss data in .data section to prevent bss data from being covered. 